### PR TITLE
feat: add service selection to inspection report

### DIFF
--- a/src/data/problems.js
+++ b/src/data/problems.js
@@ -1,8 +1,80 @@
 export const problemasEletricos = [
-  'Fiação exposta',
-  'Curto-circuito',
-  'Disjuntor desarmando',
-  'Tomada queimada'
+  // Problemas em Instalações Elétricas
+  'Fiação antiga (alumínio ou isolação ressecada)',
+  'Bitola de cabo inadequada para a carga',
+  'Conexões mal feitas (emendas mal isoladas, sem conectores adequados)',
+  'Sobrecarga de circuitos (muitos aparelhos na mesma tomada)',
+  'Ausência de DR (Dispositivo Diferencial Residual)',
+  'Ausência ou defeito no DPS (Dispositivo de Proteção contra Surtos)',
+  'Aterramento inexistente ou ineficiente',
+  'Quadro de distribuição subdimensionado',
+  'Ausência de identificação dos circuitos no quadro elétrico',
+  'Uso de fios rígidos em locais sujeitos a vibração',
+  'Tomadas sem padrão ABNT (NBR 14136)',
+  'Eletrodutos obstruídos ou mal fixados',
+  'Instalações provisórias permanentes (gambiarras)',
+  'Isolamento elétrico danificado',
+
+  // Problemas de Segurança
+  'Fios expostos em áreas de circulação',
+  'Caixa de passagem sem tampa',
+  'Quadro de energia aberto ou sem proteção',
+  'Proximidade perigosa entre fiação elétrica e redes de água/gás',
+  'Ausência de sinalização de alta tensão em áreas técnicas',
+  'Extensões e benjamins usados permanentemente',
+  'Falta de dispositivos contra incêndio (detectores, alarmes)',
+  'Painéis e cabos sobreaquecendo',
+
+  // Problemas em Iluminação
+  'Oscilação de luz (flutuação de tensão)',
+  'Lâmpadas queimando com frequência',
+  'Baixa luminosidade por projeto mal dimensionado',
+  'Luminárias mal fixadas ou com mau contato',
+  'Flicker visível (tremulação)',
+  'Driver de LED defeituoso',
+
+  // Problemas de Energia
+  'Queda frequente de disjuntores',
+  'Picos de tensão (sobretensões)',
+  'Subtensão (queda de tensão constante)',
+  'Falta de equilíbrio de fases em sistemas trifásicos',
+  'Oscilações devido a partida de motores',
+  'Perda de fase (em empresas)',
+  'Falta de correção de fator de potência (multas na conta)',
+
+  // Problemas em Equipamentos
+  'Tomadas frouxas',
+  'Interruptores quebrados ou aquecendo',
+  'Plugues derretendo',
+  'Fiação de máquinas danificada',
+  'Sobreaquecimento de motores',
+  'Falhas em sistemas de automação',
+  'Proteções térmicas inoperantes',
+  'Painéis de comando oxidados',
+
+  // Problemas Específicos de Ambientes Comerciais e Industriais
+  'Carga instalada acima da demanda contratada',
+  'Painéis sem manutenção preventiva',
+  'Cabos expostos em locais de alto tráfego',
+  'Falha em no-breaks ou sistemas de energia contínua',
+  'Geradores com partida defeituosa',
+  'Sistemas de SPDA (para-raios) sem inspeção periódica',
+  'Quadros de automação sem ventilação adequada',
+  'Falta de redundância elétrica em equipamentos críticos',
+
+  // Problemas de Normatização
+  'Instalação fora da NBR 5410 (instalações de baixa tensão)',
+  'Falta de inspeção periódica conforme NR-10',
+  'Não conformidade com NR-12 (máquinas e equipamentos)',
+  'Sistemas de emergência não testados',
+  'Cabos e conectores fora de especificação',
+
+  // Problemas Climáticos e Ambientais
+  'Oxidação de contatos por umidade',
+  'Curto-circuito por infiltração de água',
+  'Danificação de cabos por roedores/insetos',
+  'Sobretensão por descargas atmosféricas',
+  'Danos causados por calor excessivo'
 ]
 
 export const outrosProblemas = [


### PR DESCRIPTION
## Summary
- add service selection and manual services to inspection report without pricing
- include quantities with unit handling for laudos and cabling
- expand electrical problem checklist with comprehensive items

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3b075cdc8321b0f36c60fa08210f