### PR TITLE
Fix report generation bug by initializing array

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,6 +134,9 @@ function App() {
     if (!novos[key]) {
       novos[key] = { orcamentos: [], relatorios: [] };
     }
+    if (!novos[key][tipo]) {
+      novos[key][tipo] = [];
+    }
     novos[key][tipo].push({
       data: new Date().toLocaleDateString("pt-BR"),
       pdf,


### PR DESCRIPTION
## Summary
- prevent report generation error by ensuring storage structure includes requested file type

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0da6c48508321a9feaa51281fd7bb