### PR TITLE
feat: add electric particle background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ import { services, categories } from "./data/services.js";
 const logoRaizEletrica = "/logo-raizeletrica-atualizada-sem-fundo.png";
 import { problemasEletricos, outrosProblemas } from "./data/problems.js";
 import "./App.css";
+import ElectricBackground from "@/components/electric-background.jsx";
 
 function App() {
   // Utilitário para carregar imagem como base64
@@ -831,7 +832,8 @@ function App() {
   const acrescimo = calcularAcrescimoPorItem();
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
+    <div className="relative min-h-screen bg-gray-50 p-4 overflow-hidden">
+      <ElectricBackground />
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8">
           <div className="flex flex-col items-center justify-center gap-2 mb-4">

--- a/src/components/electric-background.jsx
+++ b/src/components/electric-background.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+function ElectricBackground() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    let animationFrameId;
+    let particles = [];
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+
+    const createParticle = () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      dx: (Math.random() - 0.5) * 2,
+      dy: (Math.random() - 0.5) * 2,
+    });
+
+    const initParticles = () => {
+      particles = [];
+      for (let i = 0; i < 80; i++) {
+        particles.push(createParticle());
+      }
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = "rgba(0, 150, 255, 0.7)";
+      particles.forEach((p) => {
+        p.x += p.dx;
+        p.y += p.dy;
+
+        if (p.x < 0 || p.x > canvas.width) p.dx *= -1;
+        if (p.y < 0 || p.y > canvas.height) p.dy *= -1;
+
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 2, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      ctx.strokeStyle = "rgba(0, 200, 255, 0.3)";
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const p1 = particles[i];
+          const p2 = particles[j];
+          const dist = Math.hypot(p1.x - p2.x, p1.y - p2.y);
+          if (dist < 80) {
+            ctx.lineWidth = 0.5;
+            ctx.beginPath();
+            ctx.moveTo(p1.x, p1.y);
+            ctx.lineTo(p2.x, p2.y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      animationFrameId = requestAnimationFrame(draw);
+    };
+
+    resize();
+    initParticles();
+    draw();
+    window.addEventListener("resize", () => {
+      resize();
+      initParticles();
+    });
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="absolute inset-0 -z-10" />;
+}
+
+export default ElectricBackground;


### PR DESCRIPTION
## Summary
- add canvas-based electric particle background
- render particle background behind main app content

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2e6d659708321a3cca82d6afd3b82