### PR TITLE
feat: add report references to main screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Orçamento Elétrico - PWA</title>
     
     <!-- PWA Meta Tags -->
-    <meta name="description" content="Sistema para geração de orçamentos de serviços elétricos">
+    <meta name="description" content="Sistema para geração de orçamentos de serviços elétricos e relatórios">
     <meta name="theme-color" content="#2563eb">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Orçamento Elétrico PWA",
   "short_name": "Orçamento Elétrico",
-  "description": "Sistema para geração de orçamentos de serviços elétricos",
+  "description": "Sistema para geração de orçamentos de serviços elétricos e relatórios",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1061,11 +1061,11 @@ function App() {
               }}
             />
             <h1 className="text-3xl font-bold text-gray-900">
-              Orçamento Elétrico
+              Orçamento Elétrico e Relatório
             </h1>
           </div>
           <p className="text-gray-600">
-            Sistema para geração de orçamentos de serviços elétricos
+            Sistema para geração de orçamentos de serviços elétricos e relatórios
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- update main screen title to "Orçamento Elétrico e Relatório"
- mention report generation in app and PWA meta descriptions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b196ddec83218c4f510e803e0d9e