### PR TITLE
style: apply brand gradient background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,6 +115,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background: linear-gradient(180deg, #0c0f07 0%, #37653d 50%, #f28017 100%);
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1041,7 +1041,7 @@ function App() {
   );
 
   return (
-    <div className="relative min-h-screen bg-gradient-to-br from-blue-50 to-blue-100 p-4 overflow-hidden">
+    <div className="relative min-h-screen p-4 overflow-hidden">
       <ElectricBackground />
 
       <div className="relative z-10 max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
- use Raiz Elétrica logo colors for global background gradient
- remove obsolete blue gradient classes from main container so brand colors appear

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b3ac443c8321ae8bb1eb3c4c0e34