### PR TITLE
Improve background text visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,7 +115,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply text-foreground;
+    @apply text-white;
     background: linear-gradient(180deg, #0c0f07 0%, #37653d 50%, #f28017 100%);
   }
 }


### PR DESCRIPTION
## Summary
- Make body text white to stand out against gradient background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2796f408321a3c9fb1cc6b5960f