### PR TITLE
Use white text over background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1060,11 +1060,11 @@ function App() {
                 background: "transparent",
               }}
             />
-            <h1 className="text-3xl font-bold text-gray-900">
+            <h1 className="text-3xl font-bold text-white">
               Orçamento Elétrico e Relatório
             </h1>
           </div>
-          <p className="text-gray-600">
+          <p className="text-white">
             Sistema para geração de orçamentos de serviços elétricos e relatórios
           </p>
         </div>


### PR DESCRIPTION
## Summary
- ensure background header and description text render in white for better readability

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a3c42e79b4832185dc8fd9fa5fcbb9